### PR TITLE
Fix python-version

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - run: pip install \
             mkdocs \
             mkdocs-material \


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/mkdocs.yml` file. The change updates the `python-version` specification to use a string format.

* [`.github/workflows/mkdocs.yml`](diffhunk://#diff-ac5175ca62288ff3d3d57d7f315390766083f9a99e21f56d709026e10114a551L27-R27): Changed `python-version` from `3.10` to `'3.10'`.