### PR TITLE
Add draft of OpenAPI specification for CKAN API

### DIFF
--- a/ckanext/openapi/public/static/openapi/ckan.yaml
+++ b/ckanext/openapi/public/static/openapi/ckan.yaml
@@ -15,8 +15,35 @@ info:
     name: CC BY 4.0
     url: https://creativecommons.org/licenses/by/4.0/
   version: '0.1'
-security:
-  - default: []
+components:
+  securitySchemes:
+    defaultApiKey:
+      description: 'API key provided in User > Account Settings: `{ckan-site-url}/user/{user}/api-tokens`'
+      type: apiKey
+      name: Authorization
+      in: header
+basePath: /v1
+tags:
+  - name: basic
+    description: CKAN API Basics
+    externalDocs:
+      description: CKAN’s Action API is a powerful, RPC-style API that exposes all of CKAN’s core features.
+      url: https://docs.ckan.org/en/2.10/api/
+  - name: packages
+    description: Packages (Datasets/Resources)
+    externalDocs:
+      description: For CKAN purposes, data is published in units called “datasets”
+      url: https://docs.ckan.org/en/2.10/user-guide.html#datasets-and-resources
+  - name: organizations
+    description: Groups of Users
+    externalDocs:
+      description: Organizations are the primary way to control who can see, create and update datasets in CKAN.
+      url: https://docs.ckan.org/en/2.10/maintaining/authorization.html?highlight=organizations#organizations
+  - name: groups
+    description: Collection of datasets
+    externalDocs:
+      description: Groups to create and manage collections of datasets
+      url: https://docs.ckan.org/en/2.10/api/
 paths:
   /action/package_list:
     get:
@@ -36,6 +63,8 @@ paths:
           required: false
           schema:
             type: integer
+      tags:
+      - packages
       responses:
         '200':
           description: A list of dataset names
@@ -66,10 +95,12 @@ paths:
             type: integer
         - name: page
           in: query
-          description: Deprecated: use offset
+          description: 'Deprecated: use offset'
           required: false
           schema:
             type: integer
+      tags:
+      - packages
       responses:
         '200':
           description: A list of datasets and their resources
@@ -97,3 +128,572 @@ paths:
                             type: string
                           url:
                             type: string
+  /action/group_list:
+    get:
+      summary: Return a list of the names of the site’s groups
+      description: >
+        The group_list action returns a list of the names of the site’s groups.
+      parameters:
+        - name: type
+          in: query
+          description: The type of group to list
+          required: false
+          schema:
+            type: string
+          default: group
+        - name: order_by
+          in: query
+          description: The field to sort the list by, must be 'name' or 'packages'
+          required: false
+          schema:
+            type: string
+          default: name
+        - name: sort
+          in: query
+          description: Sorting of the search results
+          required: false
+          schema:
+            type: string
+          default: title asc
+        - name: limit
+          in: query
+          description: The maximum number of groups returned
+          required: false
+          schema:
+            type: integer
+          default: 1000
+        - name: offset
+          in: query
+          description: The offset to start returning groups from
+          required: false
+          schema:
+            type: integer
+        - name: groups
+          in: query
+          description: A list of names of the groups to return
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: all_fields
+          in: query
+          description: Return group dictionaries instead of just names
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_dataset_count
+          in: query
+          description: If all_fields, include the full package_count
+          required: false
+          schema:
+            type: boolean
+          default: true
+        - name: include_extras
+          in: query
+          description: If all_fields, include the group extra fields
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_tags
+          in: query
+          description: If all_fields, include the group tags
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_groups
+          in: query
+          description: If all_fields, include the groups the groups are in
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_users
+          in: query
+          description: If all_fields, include the group users
+          required: false
+          schema:
+            type: boolean
+          default: false
+      tags:
+      - groups
+      responses:
+        '200':
+          description: A list of group names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /action/organization_list:
+    get:
+      summary: Return a list of the names of the site’s organizations
+      description: >
+        The organization_list action returns a list of the names of the site’s organizations.
+      parameters:
+        - name: type
+          in: query
+          description: The type of organization to list
+          required: false
+          schema:
+            type: string
+          default: organization
+        - name: order_by
+          in: query
+          description: The field to sort the list by, must be 'name' or 'packages'
+          required: false
+          schema:
+            type: string
+          default: name
+        - name: sort
+          in: query
+          description: Sorting of the search results
+          required: false
+          schema:
+            type: string
+          default: title asc
+        - name: limit
+          in: query
+          description: The maximum number of organizations returned
+          required: false
+          schema:
+            type: integer
+          default: 1000
+        - name: offset
+          in: query
+          description: The offset to start returning organizations from
+          required: false
+          schema:
+            type: integer
+        - name: organizations
+          in: query
+          description: A list of names of the organizations to return
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: all_fields
+          in: query
+          description: Return organization dictionaries instead of just names
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_dataset_count
+          in: query
+          description: If all_fields, include the full package_count
+          required: false
+          schema:
+            type: boolean
+          default: true
+        - name: include_extras
+          in: query
+          description: If all_fields, include the organization extra fields
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_tags
+          in: query
+          description: If all_fields, include the organization tags
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_groups
+          in: query
+          description: If all_fields, include the organizations the organizations are in
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_users
+          in: query
+          description: If all_fields, include the organization users
+          required: false
+          schema:
+            type: boolean
+          default: false
+      tags:
+      - organizations
+      responses:
+        '200':
+          description: A list of organization names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /action/license_list:
+    get:
+      summary: Return the list of licenses available for datasets on the site
+      description: >
+        The license_list action returns the list of licenses available for datasets on the site.
+      tags:
+      - basic
+      responses:
+        '200':
+          description: A list of licenses
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    title:
+                      type: string
+                    url:
+                      type: string
+  /action/tag_list:
+    get:
+      summary: Return a list of the site’s tags
+      description: >
+        The tag_list action returns a list of the site’s tags. By default only free tags (tags that don’t belong to a vocabulary) are returned. If the vocabulary_id argument is given then only tags belonging to that vocabulary will be returned instead.
+      parameters:
+        - name: query
+          in: query
+          description: A tag name query to search for, if given only tags whose names contain this string will be returned
+          required: false
+          schema:
+            type: string
+        - name: vocabulary_id
+          in: query
+          description: The id or name of a vocabulary, if given only tags that belong to this vocabulary will be returned
+          required: false
+          schema:
+            type: string
+        - name: all_fields
+          in: query
+          description: Return full tag dictionaries instead of just names
+          required: false
+          schema:
+            type: boolean
+          default: false
+      tags:
+      - basic
+      responses:
+        '200':
+          description: A list of tags
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items:
+                      type: string
+                  - type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        vocabulary_id:
+                          type: string
+  /action/package_show:
+    get:
+      summary: Return the metadata of a dataset (package) and its resources
+      description: >
+        The package_show action returns the metadata of a dataset (package) and its resources.
+      parameters:
+        - name: id
+          in: query
+          description: The id or name of the dataset
+          required: true
+          schema:
+            type: string
+        - name: use_default_schema
+          in: query
+          description: Use default package schema instead of a custom schema defined with an IDatasetForm plugin
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_tracking
+          in: query
+          description: Add tracking information to dataset and resources
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_plugin_data
+          in: query
+          description: Include the internal plugin data object (sysadmin only)
+          required: false
+          schema:
+            type: boolean
+          default: false
+      tags:
+      - packages
+      responses:
+        '200':
+          description: The metadata of the dataset
+          content:
+            application/json:
+              schema:
+                type: object
+  /action/package_search:
+    get:
+      summary: Searches for packages satisfying a given search criteria
+      description: >
+        The package_search action searches for packages satisfying a given search criteria.
+      parameters:
+        - name: q
+          in: query
+          description: The solr query
+          required: false
+          schema:
+            type: string
+          default: "*:*"
+        - name: fq
+          in: query
+          description: Any filter queries to apply
+          required: false
+          schema:
+            type: string
+        - name: fq_list
+          in: query
+          description: Additional filter queries to apply
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: sort
+          in: query
+          description: Sorting of the search results
+          required: false
+          schema:
+            type: string
+          default: 'score desc, metadata_modified desc'
+        - name: rows
+          in: query
+          description: The maximum number of matching rows (datasets) to return
+          required: false
+          schema:
+            type: integer
+          default: 10
+        - name: start
+          in: query
+          description: The offset in the complete result for where the set of returned datasets should begin
+          required: false
+          schema:
+            type: integer
+        - name: facet
+          in: query
+          description: Whether to enable faceted results
+          required: false
+          schema:
+            type: boolean
+          default: true
+        - name: facet.mincount
+          in: query
+          description: The minimum counts for facet fields should be included in the results
+          required: false
+          schema:
+            type: integer
+        - name: facet.limit
+          in: query
+          description: The maximum number of values the facet fields return
+          required: false
+          schema:
+            type: integer
+          default: 50
+        - name: facet.field
+          in: query
+          description: The fields to facet upon
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: include_drafts
+          in: query
+          description: If True, draft datasets will be included in the results
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_deleted
+          in: query
+          description: If True, deleted datasets will be included in the results
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: include_private
+          in: query
+          description: If True, private datasets will be included in the results
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: use_default_schema
+          in: query
+          description: Use default package schema instead of a custom schema defined with an IDatasetForm plugin
+          required: false
+          schema:
+            type: boolean
+          default: false
+        - name: qf
+          in: query
+          description: Query fields
+          required: false
+          schema:
+            type: string
+        - name: wt
+          in: query
+          description: Writer type
+          required: false
+          schema:
+            type: string
+        - name: bf
+          in: query
+          description: Boost functions
+          required: false
+          schema:
+            type: string
+        - name: boost
+          in: query
+          description: Boost query
+          required: false
+          schema:
+            type: string
+        - name: tie
+          in: query
+          description: Tie breaker
+          required: false
+          schema:
+            type: string
+        - name: defType
+          in: query
+          description: Default type
+          required: false
+          schema:
+            type: string
+        - name: mm
+          in: query
+          description: Minimum match
+          required: false
+          schema:
+            type: string
+      tags:
+      - packages
+      responses:
+        '200':
+          description: A dictionary of search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  results:
+                    type: array
+                    items:
+                      type: object
+                  search_facets:
+                    type: object
+  /action/resource_search:
+    get:
+      summary: Searches for resources in public Datasets satisfying the search criteria
+      description: >
+        The resource_search action searches for resources in public Datasets satisfying the search criteria.
+      parameters:
+        - name: query
+          in: query
+          description: The search criteria
+          required: true
+          schema:
+            type: string
+        - name: order_by
+          in: query
+          description: A field on the Resource model that orders the results
+          required: false
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description: Apply an offset to the query
+          required: false
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Apply a limit to the query
+          required: false
+          schema:
+            type: integer
+      tags:
+      - packages
+      responses:
+        '200':
+          description: A dictionary of search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  results:
+                    type: array
+                    items:
+                      type: object
+  /action/tag_search:
+    get:
+      summary: Return a list of tags whose names contain a given string
+      description: >
+        The tag_search action returns a list of tags whose names contain a given string. By default only free tags (tags that don’t belong to any vocabulary) are searched. If the vocabulary_id argument is given then only tags belonging to that vocabulary will be searched instead.
+      parameters:
+        - name: query
+          in: query
+          description: The string(s) to search for
+          required: false
+          schema:
+            type: string
+        - name: vocabulary_id
+          in: query
+          description: The id or name of the tag vocabulary to search in
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: The maximum number of tags to return
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: When limit is given, the offset to start returning tags from
+          required: false
+          schema:
+            type: integer
+      tags:
+      - basic
+      responses:
+        '200':
+          description: A dictionary of search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  results:
+                    type: array
+                    items:
+                      type: object

--- a/ckanext/openapi/public/static/openapi/ckan.yaml
+++ b/ckanext/openapi/public/static/openapi/ckan.yaml
@@ -1,0 +1,99 @@
+openapi: 3.0.0
+servers:
+- url: https://demo.ckan.org/api
+  description: Development Portal [PUBLIC]
+info:
+  title: Open Data Portal - Datastore API
+  description: >
+    This API provides live access to the Datastore portion of the Demo Open Data Portal. Our staging portals are for sharing upcoming features and testing restricted network integration, and development sites are for features under development.
+  termsOfService: https://creativecommons.org/licenses/by/4.0/
+  contact:
+    name: CKAN
+    url: https://ckan.org/
+    email: info@ckan.org
+  license:
+    name: CC BY 4.0
+    url: https://creativecommons.org/licenses/by/4.0/
+  version: '0.1'
+security:
+  - default: []
+paths:
+  /action/package_list:
+    get:
+      summary: Return a list of the names of the site’s datasets (packages)
+      description: >
+        The package_list action returns a list of the names of the site’s datasets (packages).
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of datasets to return
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: The offset to start returning packages from
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: A list of dataset names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /action/current_package_list_with_resources:
+    get:
+      summary: Return a list of the site’s datasets (packages) and their resources
+      description: >
+        The current_package_list_with_resources action returns a list of the site’s datasets (packages) and their resources.
+        The list is sorted most-recently-modified first.
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of datasets to return
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: The offset to start returning packages from
+          required: false
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: Deprecated: use offset
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: A list of datasets and their resources
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    resources:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          format:
+                            type: string
+                          url:
+                            type: string

--- a/ckanext/openapi/public/static/openapi/datastore-en.yaml
+++ b/ckanext/openapi/public/static/openapi/datastore-en.yaml
@@ -1,0 +1,110 @@
+openapi: 3.0.0
+servers:
+- url: https://demo.ckan.org/api
+  description: Development Portal [PUBLIC]
+info:
+  title: Open Data Portal - Datastore API
+  description: >
+    This API provides live access to the Datastore portion of the Demo Open Data Portal. Our staging portals are for sharing upcoming features and testing restricted network integration, and development sites are for features under development.
+  termsOfService: https://creativecommons.org/licenses/by/4.0/
+  contact:
+    name: CKAN
+    url: https://ckan.org/
+    email: info@ckan.org
+  license:
+    name: CC BY 4.0
+    url: https://creativecommons.org/licenses/by/4.0/
+  version: '0.1'
+security:
+  - default: []
+paths:
+  /action/datastore_search:
+    post:
+      summary: Search a datastore resource
+      description: >
+        The datastore_search action allows you to search data in a resource.
+        Well-formatted CSV files that are uploaded (not linked) are automatically loaded into the datastore.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                resource_id:
+                  type: string
+                  format: uuid
+                  description: id or alias of the resource to be searched against
+                  examples:
+                    Air Quality:
+                      value: 499383b6-cd2a-466a-9fcf-910d3e427700
+                filters:
+                  type: object
+                  description: matching conditions to select, `application/json` POST requests only
+                  examples:
+                    (Value not supported for GET requests):
+                      value: ''
+                q:
+                  oneOf:
+                  - type: string
+                    description: full text query searching across all columns in each row
+                  - type: object
+                    description: fill text search on each field given
+                distinct:
+                  type: boolean
+                  description: return only distinct rows
+                  default: false
+                plain:
+                  type: boolean
+                  description: treat as plain text query
+                  default: true
+                language:
+                  type: string
+                  description: language of the full text query
+                  default: english
+                limit:
+                  type: integer
+                  description: maximum number of rows to return
+                  default: 100
+                offset:
+                  type: integer
+                  description: offset this number of rows
+                fields:
+                  oneOf:
+                  - type: string
+                    description: comma-separated string of column names to return
+                  - type: array
+                    description: list of column names to return
+                sort:
+                  type: string
+                  description: comma-separated string of column names with sort order
+                  example: reporting_period desc, line_number
+                include_total:
+                  type: boolean
+                  description: calculate and return the total number of matching rows, set to `false` for improved performance
+                  default: true
+                records_format:
+                  type: string
+                  description: the format for the records return value, set to `csv` or `tsv` for improved performance
+                  default: objects
+                  enum:
+                  - objects
+                  - lists
+                  - csv
+                  - tsv
+            examples:
+              Air Quality:
+                value:
+                  resource_id: 499383b6-cd2a-466a-9fcf-910d3e427700
+                  q: 2020-2021
+                  filters:
+                    codine: 28
+              Top 10 most recently deleted datasets:
+                value:
+                  resource_id: d22d2aca-155b-4978-b5c1-1d39837e1993
+                  sort: '"Date and Time Deleted/Fecha y hora de eliminación" desc'
+      tags:
+      - action
+      responses:
+        '200':
+          description: List of packages (datasets) including all metadata available.

--- a/ckanext/openapi/utils.py
+++ b/ckanext/openapi/utils.py
@@ -12,6 +12,24 @@ log = logging.getLogger(__name__)
 
 OPENAPI_REQUIRED_KEYS = ['url', 'name', 'title', 'description']
 
+def get_not_lang_root_path():
+    """
+    Retrieve the root path from the CKAN configuration, removing the '{{LANG}}' placeholder if present.
+
+    This function fetches the 'ckan.root_path' configuration setting and removes the '/{{LANG}}' 
+    placeholder if it exists in the path.
+
+    Returns:
+        str: The root path with the '{{LANG}}' placeholder removed if it was present.
+    """
+    root_path = p.toolkit.config.get('ckan.root_path')
+    
+    # Removes the '{{LANG}}' part if present in the root_path
+    if root_path and '{{LANG}}' in root_path:
+        root_path = root_path.replace('/{{LANG}}', '')
+    
+    return root_path
+
 def openapi_is_valid_endpoint(endpoint):
     """
     Validates that an endpoint dictionary has the required keys and types.
@@ -83,7 +101,7 @@ def openapi_validate_endpoints():
         return oa_config.default_openapi_endpoints
 
     protocol, host = ckan_helpers.get_site_protocol_and_host()
-    root_path = p.toolkit.config.get('ckan.root_path', '')
+    root_path = get_not_lang_root_path()
 
     validated_endpoints = []
     for endpoint in endpoints:


### PR DESCRIPTION
This pull request introduces a new OpenAPI specification for the Datastore API and includes a utility function to handle language placeholders in CKAN configuration paths. The most important changes are as follows:

### OpenAPI Specification:

* Added a complete OpenAPI 3.0.0 specification for the Datastore API in `ckanext/openapi/public/static/openapi/datastore-en.yaml`. This includes server details, API information, security settings, and endpoint definitions for searching datastore resources.

### Utility Function:

* Introduced a new function `get_not_lang_root_path` in `ckanext/openapi/utils.py` to retrieve and clean the root path from CKAN configuration by removing the `{{LANG}}` placeholder if present.

### Code Refactoring:

* Updated the `openapi_validate_endpoints` function in `ckanext/openapi/utils.py` to use the new `get_not_lang_root_path` function for obtaining the root path.