### PR TITLE
Fix MKDocs Getting Started

### DIFF
--- a/docs/v1/getting-started.md
+++ b/docs/v1/getting-started.md
@@ -64,7 +64,7 @@ To install `ckanext-openapi`:
   pip install -e git+https://github.com/ckan/ckanext-scheming.git@release-3.0.0#egg=ckanext-scheming
 
   # Install the ckanext-openapi plugin
-  pip install -e "git+https://github.com/ckan/ckanext-openapi.git#egg=ckanext-openapi"
+  pip install -e "git+https://github.com/mjanez/ckanext-openapi.git#egg=ckanext-openapi"
   ```
 
 ## Config settings


### PR DESCRIPTION
* [`docs/v1/getting-started.md`](diffhunk://#diff-09699040df51ef8ad45f3130968881afd52c24c94454cac69faf1c1381209be6L67-R67): Updated the `ckanext-openapi` installation URL to use the correct repository `https://github.com/mjanez/ckanext-openapi.git` instead of the previous one (`ckan`).